### PR TITLE
Add checks to ensure API key is set before performing actions

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,18 +4,22 @@ import { Tracking } from '../helpers/tracking';
 import { TreeView } from '../views/treeview';
 import { copyToClipboard } from './copy-to-clipboard';
 import { setApiKey } from './set-api-key';
+import { checkApiKey } from '../functions/check-api-key';
 
 /**
  * Register general commands
  * @param {ExtensionContext} ctx The extension context
  */
 export async function registerCommands(ctx: ExtensionContext) {
-	ctx.subscriptions.push(
-		commands.registerCommand(Commands.setApiKey, () => setApiKey()),
-		commands.registerCommand(Commands.refresh, () => TreeView.refresh()),
-		commands.registerCommand(Commands.copyToClipboard, (x: string) => copyToClipboard(x)),
-		commands.registerCommand(Commands.trackingStart, () => Tracking.start()),
-		commands.registerCommand(Commands.trackingStop, () => Tracking.stop()),
-		commands.registerCommand(Commands.trackingUpdateInformation, () => Tracking.updateInformation())
-	);
+  // Ensure API key is set before registering commands
+  checkApiKey();
+
+  ctx.subscriptions.push(
+    commands.registerCommand(Commands.setApiKey, () => setApiKey()),
+    commands.registerCommand(Commands.refresh, () => TreeView.refresh()),
+    commands.registerCommand(Commands.copyToClipboard, (x: string) => copyToClipboard(x)),
+    commands.registerCommand(Commands.trackingStart, () => Tracking.start()),
+    commands.registerCommand(Commands.trackingStop, () => Tracking.stop()),
+    commands.registerCommand(Commands.trackingUpdateInformation, () => Tracking.updateInformation())
+  );
 }

--- a/src/commands/set-api-key.ts
+++ b/src/commands/set-api-key.ts
@@ -3,6 +3,7 @@ import { Config } from '../util/config';
 import { Context } from '../util/context';
 import { Dialogs } from '../util/dialogs';
 import { TreeView } from '../views/treeview';
+import { checkDefaultWorkspace } from '../functions/check-default-workspace';
 
 export async function setApiKey() {
 	// ask user for the api key
@@ -17,6 +18,9 @@ export async function setApiKey() {
 
 	// authenticate the SDK
 	Clockify.authenticate(apiKey);
+
+	// ensure the default workspace is set
+	await checkDefaultWorkspace();
 
 	// refresh tree view providers
 	TreeView.refresh();

--- a/src/functions/check-default-workspace.ts
+++ b/src/functions/check-default-workspace.ts
@@ -1,16 +1,27 @@
 import { Dialogs } from '../util/dialogs';
 import { Config } from './../util/config';
+import { Clockify } from '../sdk';
 
 export async function checkDefaultWorkspace(): Promise<boolean> {
-	const workspaceId = Config.get<string>('defaultWorkspaceId');
-	if (!workspaceId) {
-		const workspace = await Dialogs.selectWorkspace('Select the default workspace.');
-		if (!workspace) {
-			return false;
-		} else {
-			Config.set('defaultWorkspaceId', workspace.id, true);
-		}
-	}
+  const apiKey = Config.get<string>('apiKey');
+  if (!apiKey) {
+    const enteredApiKey = await Dialogs.askForApiKey();
+    if (!enteredApiKey) {
+      return false;
+    }
+    Config.set('apiKey', enteredApiKey, true);
+    Clockify.authenticate(enteredApiKey);
+  }
 
-	return true;
+  const workspaceId = Config.get<string>('defaultWorkspaceId');
+  if (!workspaceId) {
+    const workspace = await Dialogs.selectWorkspace('Select the default workspace.');
+    if (!workspace) {
+      return false;
+    } else {
+      Config.set('defaultWorkspaceId', workspace.id, true);
+    }
+  }
+
+  return true;
 }

--- a/src/util/dialogs.ts
+++ b/src/util/dialogs.ts
@@ -26,8 +26,8 @@ export class Dialogs {
 
 	public static async askForApiKey(apiKey?: string): Promise<string | undefined> {
 		return window.showInputBox({
-			prompt: 'Enter your API key.',
-			placeHolder: 'Enter your API key',
+			prompt: 'Enter your API key',
+			placeHolder: 'Clockify extension needs the API key to work',
 			ignoreFocusOut: true,
 			value: apiKey,
 		});

--- a/src/views/treeview/workspaces/commands/select-workspace.ts
+++ b/src/views/treeview/workspaces/commands/select-workspace.ts
@@ -1,25 +1,32 @@
 import { TreeView } from '../..';
 import { Workspace } from '../../../../sdk/types/workspace';
 import { GlobalState } from '../../../../util/global-state';
+import { checkDefaultWorkspace } from '../../../../functions/check-default-workspace';
+import { checkApiKey } from '../../../../functions/check-api-key';
 
 export async function selectWorkspace(workspace: Workspace): Promise<void> {
-	const selectedWorkspace = GlobalState.get<Workspace>('selectedWorkspace');
+  // Ensure API key is set before fetching workspaces
+  checkApiKey();
 
-	// skip if workspace is already selected
-	if (selectedWorkspace && selectedWorkspace.id === workspace.id) {
-		return;
-	}
+  const selectedWorkspace = GlobalState.get<Workspace>('selectedWorkspace');
 
-	if (workspace) {
-		GlobalState.set('selectedWorkspace', workspace);
-		GlobalState.set('selectedClient', null);
-		GlobalState.set('selectedProject', null);
+  // skip if workspace is already selected
+  if (selectedWorkspace && selectedWorkspace.id === workspace.id) {
+    return;
+  }
 
-		TreeView.refreshWorkspaces();
-		TreeView.refreshClients();
-		TreeView.refreshProjects();
-		TreeView.refreshTasks();
-		TreeView.refreshTags();
-		TreeView.refreshTimeentries();
-	}
+  if (workspace) {
+    GlobalState.set('selectedWorkspace', workspace);
+    GlobalState.set('selectedClient', null);
+    GlobalState.set('selectedProject', null);
+
+    await checkDefaultWorkspace();
+
+    TreeView.refreshWorkspaces();
+    TreeView.refreshClients();
+    TreeView.refreshProjects();
+    TreeView.refreshTasks();
+    TreeView.refreshTags();
+    TreeView.refreshTimeentries();
+  }
 }


### PR DESCRIPTION

This pull request introduces several changes to ensure that the API key and default workspace are set before executing certain commands. The changes focus on improving the reliability and user experience of the extension by adding checks and prompts for necessary configurations.

### Enhancements to command registration and execution:

* [`src/commands/index.ts`](diffhunk://#diff-a6a1db61476382a80351bf0b40126b3cfca87878293a3fca70dfe04367f4a11fR7-R16): Added a call to `checkApiKey` to ensure the API key is set before registering commands.
* [`src/commands/set-api-key.ts`](diffhunk://#diff-0c94a68d2ee8a04ea89ac7314700c342a57f1782e246d7593cd5e34248ac9df0R22-R24): Added a call to `checkDefaultWorkspace` to ensure the default workspace is set after setting the API key.

### New functions for configuration checks:

* [`src/functions/check-default-workspace.ts`](diffhunk://#diff-f047386a41cbf0aa49a7081ec81d914996d9c4f09b5a926816ec2247598bd124R3-R15): Added a function to check and prompt for the default workspace if it's not set. This includes authenticating with the API key if needed.

### Updates to dialogs:

* [`src/util/dialogs.ts`](diffhunk://#diff-0b4de0e2a6bdb11ddb1f9829b2cc6ba6af6481ab7ed755deb8169fe3f53ba542L29-R30): Modified the `askForApiKey` method to improve the prompt and placeholder text for better user clarity.

### Ensuring configurations in workspace selection:

* [`src/views/treeview/workspaces/commands/select-workspace.ts`](diffhunk://#diff-811c3503ad82702097609a72e5c0245646732c28c263eb85afecf0dd1f6b1890R4-R10): Added calls to `checkApiKey` and `checkDefaultWorkspace` to ensure necessary configurations are set before fetching and selecting workspaces. [[1]](diffhunk://#diff-811c3503ad82702097609a72e5c0245646732c28c263eb85afecf0dd1f6b1890R4-R10) [[2]](diffhunk://#diff-811c3503ad82702097609a72e5c0245646732c28c263eb85afecf0dd1f6b1890R23-R24)